### PR TITLE
remove update command

### DIFF
--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -2,13 +2,9 @@ package cli
 
 import (
 	"fmt"
-	"net/http"
-	"runtime"
 
 	"github.com/convox/rack/sdk"
 	"github.com/convox/stdcli"
-	cv "github.com/convox/version"
-	update "github.com/inconshreveable/go-update"
 )
 
 func init() {
@@ -19,36 +15,5 @@ func init() {
 }
 
 func Update(rack sdk.Interface, c *stdcli.Context) error {
-	target := c.Arg(0)
-
-	// if no version specified, find the latest version
-	if target == "" {
-		v, err := cv.Latest()
-		if err != nil {
-			return err
-		}
-
-		target = v
-	}
-
-	url := fmt.Sprintf("https://s3.amazonaws.com/convox/release/%s/cli/%s/%s", target, runtime.GOOS, executableName())
-
-	res, err := http.Get(url)
-	if err != nil {
-		return err
-	}
-
-	if res.StatusCode != 200 {
-		return fmt.Errorf("invalid version")
-	}
-
-	defer res.Body.Close()
-
-	c.Startf("Updating to <release>%s</release>", target)
-
-	if err := update.Apply(res.Body, update.Options{}); err != nil {
-		return err
-	}
-
-	return c.OK()
+	return fmt.Errorf("since this is a custom build, it should be updated manually")
 }


### PR DESCRIPTION
modify the `convox update` command to avoid accidentally downloading the latest version